### PR TITLE
Correct No license field warning

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "svelte-app",
   "version": "1.0.0",
+  "license": "MIT",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w"


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

```
warning package.json: No license field
```