### PR TITLE
fixes #31, Adding option to disable SMTP auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ You can specify configuration options either via a config file (`config.yml`) or
 | `web.public_url`          | `MW_PUBLIC_URL`              | `http://localhost:3000`   | The URL under which your MailWhale server is available from the public internet    |
 | `smtp.host`               | `MW_SMTP_HOST`               | -                         | SMTP relay host name or IP                                                         |
 | `smtp.port`               | `MW_SMTP_PORT`               | -                         | SMTP relay port                                                                    |
+| `smtp.auth`               | `MW_SMTP_AUTH`               | `true`                    | SMTP relay uses authentication                                                     |
 | `smtp.username`           | `MW_SMTP_USER`               | -                         | SMTP relay authentication user name                                                |
 | `smtp.password`           | `MW_SMTP_PASS`               | -                         | SMTP relay authentication password                                                 |
 | `smtp.tls`                | `MW_SMTP_TLS`                | `false`                   | Whether to require full TLS (not to be confused with STARTTLS) for the SMTP relay  |

--- a/config.default.yml
+++ b/config.default.yml
@@ -13,6 +13,7 @@ web:
 smtp:
   host: 'localhost'
   port: 465
+  auth: true
   username: 'you@example.org'
   password: 'your secret password'
   tls: true                           # Whether to connect via SSL/TLS (set 'false' for STARTTLS)

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type mailConfig struct {
 type smtpConfig struct {
 	Host          string `env:"MW_SMTP_HOST"`
 	Port          uint   `env:"MW_SMTP_PORT"`
+	Auth          bool   `yaml:"auth" env:"MW_SMTP_AUTH" default:"true"`
 	Username      string `env:"MW_SMTP_USER"`
 	Password      string `env:"MW_SMTP_PASS"`
 	TLS           bool   `env:"MW_SMTP_TLS"`

--- a/service/send.go
+++ b/service/send.go
@@ -17,6 +17,11 @@ type SendService struct {
 
 func NewSendService() *SendService {
 	config := conf.Get()
+
+	if config.Smtp.Auth == false {
+		return &SendService{config: config, auth: nil}
+	}
+
 	return &SendService{
 		config: config,
 		auth: sasl.NewPlainClient(


### PR DESCRIPTION
Adding a option `smtp.auth` and `MW_SMTP_AUTH` to cater for smtp authentication handling.